### PR TITLE
Expand pgp_update generation, more options for key gen

### DIFF
--- a/examples/4.cson
+++ b/examples/4.cson
@@ -1,0 +1,35 @@
+
+chain :
+  user : "zapu"
+  ctime : "1000"
+  expire_in : 10000000
+  links : [
+    {
+      # ctime implied from chain ctime = 1000
+
+      type : "eldest"
+      label : "e"
+
+      key : {
+        gen : "pgp_ecc"
+
+        # Will result in generation time of 1200, but not affect
+        # "current time". So it simulates someone uploading key
+        # from the future.
+        generated: "+200"
+      }
+
+      userid: "zapu <zapu@keybase.io>"
+
+      key_expire_in: 500 # Expires at 1000+500
+    }
+    {
+      ctime: "+1000" # Current time now: 1000 + 1000 = 2000
+      type : "pgp_update"
+      signer : "e"
+      pgp_update_key: "e"
+      label: "f"
+      userid: "zapu" # Change identity of key
+      key_expire_in: 500 # Expires at 2000+500
+    }
+  ]

--- a/lib/forge.js
+++ b/lib/forge.js
@@ -130,10 +130,12 @@
         return (function(__iced_k) {
           __iced_deferrals = new iced.Deferrals(__iced_k, {
             parent: ___iced_passed_deferral,
-            filename: "/Users/sidney/src/keybase/node-forge-sigchain/src/forge.iced",
+            filename: "/home/zapu/pgp/mikeboers/node-forge-sigchain/src/forge.iced",
             funcname: "Forge._make_key"
           });
-          km.export_public({}, esc(__iced_deferrals.defer({
+          km.export_public({
+            regen: true
+          }, esc(__iced_deferrals.defer({
             assign_fn: (function() {
               return function() {
                 return bundle = arguments[0];
@@ -152,21 +154,42 @@
       })(this));
     };
 
-    Forge.prototype._compute_time = function(o) {
+    Forge.prototype._compute_time_or_default = function(linkdesc, field) {
+      if (field != null) {
+        return this._compute_time(field);
+      } else {
+        return linkdesc.ctime;
+      }
+    };
+
+    Forge.prototype._compute_time = function(o, advance) {
       var m, ret, sum, term, tmp;
+      if (advance == null) {
+        advance = false;
+      }
       ret = (function() {
         var _i, _len, _ref1;
         if (typeof o === 'string') {
           if (o === 'now') {
             return this._compute_now();
-          } else if (!(m = o.match(/^(\+)?(\d+)$/))) {
+          } else if (!(m = o.match(/^([\+-])?(\d+)$/))) {
             return null;
           } else if (m[1] != null) {
-            tmp = this._compute_now() + parseInt(m[2]);
-            this._now = tmp;
+            if (m[1] === '+') {
+              tmp = this._compute_now() + parseInt(m[2]);
+              if (advance) {
+                this._now = tmp;
+              }
+            } else {
+              tmp = this._compute_now() - parseInt(m[2]);
+            }
             return tmp;
           } else {
-            return parseInt(m[2]);
+            tmp = parseInt(m[2]);
+            if (advance) {
+              this._now = tmp;
+            }
+            return tmp;
           }
         } else if (typeof o !== 'object') {
           return null;
@@ -191,7 +214,7 @@
     Forge.prototype._init = function(cb) {
       var e, err, t;
       try {
-        this._start = (t = this.get_chain().time) != null ? this._compute_time(t) : this._compute_now();
+        this._start = (t = this.get_chain().ctime) != null ? this._compute_time(t, true) : this._compute_now();
         this._expire_in = this.get_chain().expire_in || 60 * 60 * 24 * 364 * 10;
         this._username = this.get_chain().user || "tester_ralph";
         this._uid = this.get_chain().uid || username_to_uid(this._username);
@@ -203,8 +226,9 @@
     };
 
     Forge.prototype._forge_link = function(_arg, cb) {
-      var linkdesc;
+      var linkdesc, t;
       linkdesc = _arg.linkdesc;
+      linkdesc.ctime = (t = linkdesc.ctime) != null ? this._compute_time(t, true) : this._compute_now();
       switch (linkdesc.type) {
         case 'eldest':
           return this._forge_eldest_link({
@@ -232,10 +256,11 @@
     };
 
     Forge.prototype._gen_key = function(_arg, cb) {
-      var esc, key, km, obj, required, typ, ___iced_passed_deferral, __iced_deferrals, __iced_k;
+      var esc, key, km, obj, required, t, typ, userid, ___iced_passed_deferral, __iced_deferrals, __iced_k;
       __iced_k = __iced_k_noop;
       ___iced_passed_deferral = iced.findDeferral(arguments);
       obj = _arg.obj, required = _arg.required;
+      userid = obj.userid || this._username;
       esc = make_esc(cb, "_gen_key");
       (function(_this) {
         return (function(__iced_k) {
@@ -247,7 +272,7 @@
                   (function(__iced_k) {
                     __iced_deferrals = new iced.Deferrals(__iced_k, {
                       parent: ___iced_passed_deferral,
-                      filename: "/Users/sidney/src/keybase/node-forge-sigchain/src/forge.iced",
+                      filename: "/home/zapu/pgp/mikeboers/node-forge-sigchain/src/forge.iced",
                       funcname: "Forge._gen_key"
                     });
                     kbpgp.kb.KeyManager.generate({}, esc(__iced_deferrals.defer({
@@ -256,7 +281,7 @@
                           return km = arguments[0];
                         };
                       })(),
-                      lineno: 154
+                      lineno: 179
                     })));
                     __iced_deferrals._fulfill();
                   })(__iced_k);
@@ -265,7 +290,7 @@
                   (function(__iced_k) {
                     __iced_deferrals = new iced.Deferrals(__iced_k, {
                       parent: ___iced_passed_deferral,
-                      filename: "/Users/sidney/src/keybase/node-forge-sigchain/src/forge.iced",
+                      filename: "/home/zapu/pgp/mikeboers/node-forge-sigchain/src/forge.iced",
                       funcname: "Forge._gen_key"
                     });
                     kbpgp.kb.EncKeyManager.generate({}, esc(__iced_deferrals.defer({
@@ -274,7 +299,7 @@
                           return km = arguments[0];
                         };
                       })(),
-                      lineno: 156
+                      lineno: 181
                     })));
                     __iced_deferrals._fulfill();
                   })(__iced_k);
@@ -283,61 +308,66 @@
                   (function(__iced_k) {
                     __iced_deferrals = new iced.Deferrals(__iced_k, {
                       parent: ___iced_passed_deferral,
-                      filename: "/Users/sidney/src/keybase/node-forge-sigchain/src/forge.iced",
+                      filename: "/home/zapu/pgp/mikeboers/node-forge-sigchain/src/forge.iced",
                       funcname: "Forge._gen_key"
                     });
                     kbpgp.KeyManager.generate_rsa({
-                      userid: _this._username
+                      userid: userid
                     }, esc(__iced_deferrals.defer({
                       assign_fn: (function() {
                         return function() {
                           return km = arguments[0];
                         };
                       })(),
-                      lineno: 158
+                      lineno: 183
                     })));
                     __iced_deferrals._fulfill();
                   })(function() {
                     (function(__iced_k) {
                       __iced_deferrals = new iced.Deferrals(__iced_k, {
                         parent: ___iced_passed_deferral,
-                        filename: "/Users/sidney/src/keybase/node-forge-sigchain/src/forge.iced",
+                        filename: "/home/zapu/pgp/mikeboers/node-forge-sigchain/src/forge.iced",
                         funcname: "Forge._gen_key"
                       });
                       km.sign({}, esc(__iced_deferrals.defer({
-                        lineno: 159
+                        lineno: 184
                       })));
                       __iced_deferrals._fulfill();
                     })(__iced_k);
                   });
                   break;
                 case 'pgp_ecc':
+                  t = _this._compute_time_or_default(obj, obj.key.generated);
                   (function(__iced_k) {
                     __iced_deferrals = new iced.Deferrals(__iced_k, {
                       parent: ___iced_passed_deferral,
-                      filename: "/Users/sidney/src/keybase/node-forge-sigchain/src/forge.iced",
+                      filename: "/home/zapu/pgp/mikeboers/node-forge-sigchain/src/forge.iced",
                       funcname: "Forge._gen_key"
                     });
                     kbpgp.KeyManager.generate_ecc({
-                      userid: _this._username
+                      userid: userid,
+                      generated: t,
+                      expire_in: {
+                        primary: obj.key.expire_in
+                      }
                     }, esc(__iced_deferrals.defer({
                       assign_fn: (function() {
                         return function() {
                           return km = arguments[0];
                         };
                       })(),
-                      lineno: 161
+                      lineno: 187
                     })));
                     __iced_deferrals._fulfill();
                   })(function() {
                     (function(__iced_k) {
                       __iced_deferrals = new iced.Deferrals(__iced_k, {
                         parent: ___iced_passed_deferral,
-                        filename: "/Users/sidney/src/keybase/node-forge-sigchain/src/forge.iced",
+                        filename: "/home/zapu/pgp/mikeboers/node-forge-sigchain/src/forge.iced",
                         funcname: "Forge._gen_key"
                       });
                       km.sign({}, esc(__iced_deferrals.defer({
-                        lineno: 162
+                        lineno: 188
                       })));
                       __iced_deferrals._fulfill();
                     })(__iced_k);
@@ -347,11 +377,11 @@
                   (function(__iced_k) {
                     __iced_deferrals = new iced.Deferrals(__iced_k, {
                       parent: ___iced_passed_deferral,
-                      filename: "/Users/sidney/src/keybase/node-forge-sigchain/src/forge.iced",
+                      filename: "/home/zapu/pgp/mikeboers/node-forge-sigchain/src/forge.iced",
                       funcname: "Forge._gen_key"
                     });
                     athrow(new Error("unknown key type: " + typ), __iced_deferrals.defer({
-                      lineno: 164
+                      lineno: 190
                     }));
                     __iced_deferrals._fulfill();
                   })(__iced_k);
@@ -363,11 +393,11 @@
                 (function(__iced_k) {
                   __iced_deferrals = new iced.Deferrals(__iced_k, {
                     parent: ___iced_passed_deferral,
-                    filename: "/Users/sidney/src/keybase/node-forge-sigchain/src/forge.iced",
+                    filename: "/home/zapu/pgp/mikeboers/node-forge-sigchain/src/forge.iced",
                     funcname: "Forge._gen_key"
                   });
                   athrow(new Error("Required to generate key but none found"), __iced_deferrals.defer({
-                    lineno: 166
+                    lineno: 192
                   }));
                   __iced_deferrals._fulfill();
                 })(__iced_k);
@@ -385,7 +415,7 @@
               (function(__iced_k) {
                 __iced_deferrals = new iced.Deferrals(__iced_k, {
                   parent: ___iced_passed_deferral,
-                  filename: "/Users/sidney/src/keybase/node-forge-sigchain/src/forge.iced",
+                  filename: "/home/zapu/pgp/mikeboers/node-forge-sigchain/src/forge.iced",
                   funcname: "Forge._gen_key"
                 });
                 _this._make_key({
@@ -397,7 +427,7 @@
                       return key = arguments[0];
                     };
                   })(),
-                  lineno: 169
+                  lineno: 195
                 })));
                 __iced_deferrals._fulfill();
               })(__iced_k);
@@ -412,7 +442,7 @@
     };
 
     Forge.prototype._populate_proof = function(_arg) {
-      var linkdesc, proof, t;
+      var linkdesc, proof;
       linkdesc = _arg.linkdesc, proof = _arg.proof;
       proof.seqno = linkdesc.seqno || this._seqno++;
       proof.prev = linkdesc.prev || this._prev;
@@ -424,7 +454,7 @@
         }
       };
       proof.seq_type = proofs.constants.seq_types.PUBLIC;
-      proof.ctime = (t = linkdesc.ctime) != null ? this._compute_time(t) : this._compute_now();
+      proof.ctime = linkdesc.ctime;
       return proof.expire_in = this._get_expire_in({
         obj: linkdesc
       });
@@ -440,7 +470,7 @@
         return (function(__iced_k) {
           __iced_deferrals = new iced.Deferrals(__iced_k, {
             parent: ___iced_passed_deferral,
-            filename: "/Users/sidney/src/keybase/node-forge-sigchain/src/forge.iced",
+            filename: "/home/zapu/pgp/mikeboers/node-forge-sigchain/src/forge.iced",
             funcname: "Forge._forge_eldest_link"
           });
           _this._gen_key({
@@ -452,7 +482,7 @@
                 return key = arguments[0];
               };
             })(),
-            lineno: 190
+            lineno: 216
           })));
           __iced_deferrals._fulfill();
         });
@@ -464,14 +494,14 @@
           (function(__iced_k) {
             __iced_deferrals = new iced.Deferrals(__iced_k, {
               parent: ___iced_passed_deferral,
-              filename: "/Users/sidney/src/keybase/node-forge-sigchain/src/forge.iced",
+              filename: "/home/zapu/pgp/mikeboers/node-forge-sigchain/src/forge.iced",
               funcname: "Forge._forge_eldest_link"
             });
             _this._sign_and_commit_link({
               linkdesc: linkdesc,
               proof: proof
             }, esc(__iced_deferrals.defer({
-              lineno: 194
+              lineno: 220
             })));
             __iced_deferrals._fulfill();
           })(function() {
@@ -492,7 +522,7 @@
         return (function(__iced_k) {
           __iced_deferrals = new iced.Deferrals(__iced_k, {
             parent: ___iced_passed_deferral,
-            filename: "/Users/sidney/src/keybase/node-forge-sigchain/src/forge.iced",
+            filename: "/home/zapu/pgp/mikeboers/node-forge-sigchain/src/forge.iced",
             funcname: "Forge._forge_subkey_link"
           });
           _this._gen_key({
@@ -504,7 +534,7 @@
                 return key = arguments[0];
               };
             })(),
-            lineno: 202
+            lineno: 228
           })));
           __iced_deferrals._fulfill();
         });
@@ -517,11 +547,11 @@
               (function(__iced_k) {
                 __iced_deferrals = new iced.Deferrals(__iced_k, {
                   parent: ___iced_passed_deferral,
-                  filename: "/Users/sidney/src/keybase/node-forge-sigchain/src/forge.iced",
+                  filename: "/home/zapu/pgp/mikeboers/node-forge-sigchain/src/forge.iced",
                   funcname: "Forge._forge_subkey_link"
                 });
                 athrow(err, esc(__iced_deferrals.defer({
-                  lineno: 206
+                  lineno: 232
                 })));
                 __iced_deferrals._fulfill();
               })(__iced_k);
@@ -538,14 +568,14 @@
             (function(__iced_k) {
               __iced_deferrals = new iced.Deferrals(__iced_k, {
                 parent: ___iced_passed_deferral,
-                filename: "/Users/sidney/src/keybase/node-forge-sigchain/src/forge.iced",
+                filename: "/home/zapu/pgp/mikeboers/node-forge-sigchain/src/forge.iced",
                 funcname: "Forge._forge_subkey_link"
               });
               _this._sign_and_commit_link({
                 linkdesc: linkdesc,
                 proof: proof
               }, esc(__iced_deferrals.defer({
-                lineno: 213
+                lineno: 239
               })));
               __iced_deferrals._fulfill();
             })(function() {
@@ -566,7 +596,7 @@
         return (function(__iced_k) {
           __iced_deferrals = new iced.Deferrals(__iced_k, {
             parent: ___iced_passed_deferral,
-            filename: "/Users/sidney/src/keybase/node-forge-sigchain/src/forge.iced",
+            filename: "/home/zapu/pgp/mikeboers/node-forge-sigchain/src/forge.iced",
             funcname: "Forge._forge_sibkey_link"
           });
           _this._gen_key({
@@ -578,7 +608,7 @@
                 return key = arguments[0];
               };
             })(),
-            lineno: 220
+            lineno: 246
           })));
           __iced_deferrals._fulfill();
         });
@@ -591,11 +621,11 @@
               (function(__iced_k) {
                 __iced_deferrals = new iced.Deferrals(__iced_k, {
                   parent: ___iced_passed_deferral,
-                  filename: "/Users/sidney/src/keybase/node-forge-sigchain/src/forge.iced",
+                  filename: "/home/zapu/pgp/mikeboers/node-forge-sigchain/src/forge.iced",
                   funcname: "Forge._forge_sibkey_link"
                 });
                 athrow(err, esc(__iced_deferrals.defer({
-                  lineno: 224
+                  lineno: 250
                 })));
                 __iced_deferrals._fulfill();
               })(__iced_k);
@@ -611,14 +641,14 @@
             (function(__iced_k) {
               __iced_deferrals = new iced.Deferrals(__iced_k, {
                 parent: ___iced_passed_deferral,
-                filename: "/Users/sidney/src/keybase/node-forge-sigchain/src/forge.iced",
+                filename: "/home/zapu/pgp/mikeboers/node-forge-sigchain/src/forge.iced",
                 funcname: "Forge._forge_sibkey_link"
               });
               _this._sign_and_commit_link({
                 linkdesc: linkdesc,
                 proof: proof
               }, esc(__iced_deferrals.defer({
-                lineno: 230
+                lineno: 256
               })));
               __iced_deferrals._fulfill();
             })(function() {
@@ -643,11 +673,11 @@
             (function(__iced_k) {
               __iced_deferrals = new iced.Deferrals(__iced_k, {
                 parent: ___iced_passed_deferral,
-                filename: "/Users/sidney/src/keybase/node-forge-sigchain/src/forge.iced",
+                filename: "/home/zapu/pgp/mikeboers/node-forge-sigchain/src/forge.iced",
                 funcname: "Forge._forge_revoke_link"
               });
               athrow(err, esc(__iced_deferrals.defer({
-                lineno: 240
+                lineno: 266
               })));
               __iced_deferrals._fulfill();
             })(__iced_k);
@@ -672,11 +702,11 @@
                   (function(__iced_k) {
                     __iced_deferrals = new iced.Deferrals(__iced_k, {
                       parent: ___iced_passed_deferral,
-                      filename: "/Users/sidney/src/keybase/node-forge-sigchain/src/forge.iced",
+                      filename: "/home/zapu/pgp/mikeboers/node-forge-sigchain/src/forge.iced",
                       funcname: "Forge._forge_revoke_link"
                     });
                     athrow(err, esc(__iced_deferrals.defer({
-                      lineno: 250
+                      lineno: 276
                     })));
                     __iced_deferrals._fulfill();
                   })(__iced_k);
@@ -704,11 +734,11 @@
                       (function(__iced_k) {
                         __iced_deferrals = new iced.Deferrals(__iced_k, {
                           parent: ___iced_passed_deferral,
-                          filename: "/Users/sidney/src/keybase/node-forge-sigchain/src/forge.iced",
+                          filename: "/home/zapu/pgp/mikeboers/node-forge-sigchain/src/forge.iced",
                           funcname: "Forge._forge_revoke_link"
                         });
                         athrow(err, esc(__iced_deferrals.defer({
-                          lineno: 261
+                          lineno: 287
                         })));
                         __iced_deferrals._fulfill();
                       })(__iced_k);
@@ -726,11 +756,11 @@
                           (function(__iced_k) {
                             __iced_deferrals = new iced.Deferrals(__iced_k, {
                               parent: ___iced_passed_deferral,
-                              filename: "/Users/sidney/src/keybase/node-forge-sigchain/src/forge.iced",
+                              filename: "/home/zapu/pgp/mikeboers/node-forge-sigchain/src/forge.iced",
                               funcname: "Forge._forge_revoke_link"
                             });
                             athrow(err, esc(__iced_deferrals.defer({
-                              lineno: 265
+                              lineno: 291
                             })));
                             __iced_deferrals._fulfill();
                           })(__iced_k);
@@ -758,11 +788,11 @@
                               (function(__iced_k) {
                                 __iced_deferrals = new iced.Deferrals(__iced_k, {
                                   parent: ___iced_passed_deferral,
-                                  filename: "/Users/sidney/src/keybase/node-forge-sigchain/src/forge.iced",
+                                  filename: "/home/zapu/pgp/mikeboers/node-forge-sigchain/src/forge.iced",
                                   funcname: "Forge._forge_revoke_link"
                                 });
                                 athrow(err, esc(__iced_deferrals.defer({
-                                  lineno: 276
+                                  lineno: 302
                                 })));
                                 __iced_deferrals._fulfill();
                               })(__iced_k);
@@ -784,14 +814,14 @@
             (function(__iced_k) {
               __iced_deferrals = new iced.Deferrals(__iced_k, {
                 parent: ___iced_passed_deferral,
-                filename: "/Users/sidney/src/keybase/node-forge-sigchain/src/forge.iced",
+                filename: "/home/zapu/pgp/mikeboers/node-forge-sigchain/src/forge.iced",
                 funcname: "Forge._forge_revoke_link"
               });
               _this._sign_and_commit_link({
                 linkdesc: linkdesc,
                 proof: proof
               }, esc(__iced_deferrals.defer({
-                lineno: 280
+                lineno: 306
               })));
               __iced_deferrals._fulfill();
             })(function() {
@@ -803,34 +833,95 @@
     };
 
     Forge.prototype._forge_pgp_update_link = function(_arg, cb) {
-      var esc, linkdesc, proof, ___iced_passed_deferral, __iced_deferrals, __iced_k;
+      var esc, key, lifespan, linkdesc, old_ekid, proof, uid, ___iced_passed_deferral, __iced_deferrals, __iced_k;
       __iced_k = __iced_k_noop;
       ___iced_passed_deferral = iced.findDeferral(arguments);
       linkdesc = _arg.linkdesc;
       esc = make_esc(cb, "_forge_pgp_update_link");
+      key = this._keyring.label[linkdesc.pgp_update_key];
       proof = new proofs.PGPUpdate({
         sig_eng: this._keyring.label[linkdesc.signer].km.make_sig_eng(),
-        pgpkm: this._keyring.label[linkdesc.pgp_update_key].km,
+        pgpkm: key.km,
         eldest_kid: this._eldest_kid
       });
+      old_ekid = key.km.get_ekid();
+      lifespan = key.km.primary.lifespan;
+      lifespan.expire_in = linkdesc.key_expire_in;
+      if (linkdesc.generated != null) {
+        lifespan.generated = this._compute_time(linkdesc.generated);
+      }
+      if (uid = linkdesc.userid) {
+        key.km.userids[0] = new kbpgp.opkts.UserID(uid);
+      }
+      key.km.clear_pgp_internal_sigs();
       (function(_this) {
         return (function(__iced_k) {
           __iced_deferrals = new iced.Deferrals(__iced_k, {
             parent: ___iced_passed_deferral,
-            filename: "/Users/sidney/src/keybase/node-forge-sigchain/src/forge.iced",
+            filename: "/home/zapu/pgp/mikeboers/node-forge-sigchain/src/forge.iced",
             funcname: "Forge._forge_pgp_update_link"
           });
-          _this._sign_and_commit_link({
-            linkdesc: linkdesc,
-            proof: proof
-          }, esc(__iced_deferrals.defer({
-            lineno: 292
+          key.km.sign({}, esc(__iced_deferrals.defer({
+            lineno: 335
           })));
           __iced_deferrals._fulfill();
         });
       })(this)((function(_this) {
         return function() {
-          return cb(null);
+          (function(__iced_k) {
+            __iced_deferrals = new iced.Deferrals(__iced_k, {
+              parent: ___iced_passed_deferral,
+              filename: "/home/zapu/pgp/mikeboers/node-forge-sigchain/src/forge.iced",
+              funcname: "Forge._forge_pgp_update_link"
+            });
+            _this._make_key({
+              obj: linkdesc,
+              km: key.km
+            }, esc(__iced_deferrals.defer({
+              assign_fn: (function() {
+                return function() {
+                  return key = arguments[0];
+                };
+              })(),
+              lineno: 336
+            })));
+            __iced_deferrals._fulfill();
+          })(function() {
+            (function(__iced_k) {
+              __iced_deferrals = new iced.Deferrals(__iced_k, {
+                parent: ___iced_passed_deferral,
+                filename: "/home/zapu/pgp/mikeboers/node-forge-sigchain/src/forge.iced",
+                funcname: "Forge._forge_pgp_update_link"
+              });
+              _this._sign_and_commit_link({
+                linkdesc: linkdesc,
+                proof: proof
+              }, esc(__iced_deferrals.defer({
+                lineno: 338
+              })));
+              __iced_deferrals._fulfill();
+            })(function() {
+              (function(__iced_k) {
+                if (!key.km.get_ekid().equals(old_ekid)) {
+                  (function(__iced_k) {
+                    __iced_deferrals = new iced.Deferrals(__iced_k, {
+                      parent: ___iced_passed_deferral,
+                      filename: "/home/zapu/pgp/mikeboers/node-forge-sigchain/src/forge.iced",
+                      funcname: "Forge._forge_pgp_update_link"
+                    });
+                    athrow(new Error('update failed : different ekid'), esc(__iced_deferrals.defer({
+                      lineno: 341
+                    })));
+                    __iced_deferrals._fulfill();
+                  })(__iced_k);
+                } else {
+                  return __iced_k();
+                }
+              })(function() {
+                return cb(null);
+              });
+            });
+          });
         };
       })(this));
     };
@@ -849,7 +940,7 @@
         return (function(__iced_k) {
           __iced_deferrals = new iced.Deferrals(__iced_k, {
             parent: ___iced_passed_deferral,
-            filename: "/Users/sidney/src/keybase/node-forge-sigchain/src/forge.iced",
+            filename: "/home/zapu/pgp/mikeboers/node-forge-sigchain/src/forge.iced",
             funcname: "Forge._sign_and_commit_link"
           });
           proof.generate(esc(__iced_deferrals.defer({
@@ -858,7 +949,7 @@
                 return generate_res = arguments[0];
               };
             })(),
-            lineno: 300
+            lineno: 350
           })));
           __iced_deferrals._fulfill();
         });
@@ -890,11 +981,11 @@
         return (function(__iced_k) {
           __iced_deferrals = new iced.Deferrals(__iced_k, {
             parent: ___iced_passed_deferral,
-            filename: "/Users/sidney/src/keybase/node-forge-sigchain/src/forge.iced",
+            filename: "/home/zapu/pgp/mikeboers/node-forge-sigchain/src/forge.iced",
             funcname: "Forge.forge"
           });
           _this._init(esc(__iced_deferrals.defer({
-            lineno: 315
+            lineno: 365
           })));
           __iced_deferrals._fulfill();
         });
@@ -936,45 +1027,63 @@
                     name = _keys[_i];
                     parts = _ref1[name];
                     (function(__iced_k) {
-                      __iced_deferrals = new iced.Deferrals(__iced_k, {
-                        parent: ___iced_passed_deferral,
-                        filename: "/Users/sidney/src/keybase/node-forge-sigchain/src/forge.iced",
-                        funcname: "Forge.forge"
-                      });
-                      kbpgp.KeyManager.import_from_armored_pgp({
-                        armored: parts["public"]
-                      }, esc(__iced_deferrals.defer({
-                        assign_fn: (function() {
-                          return function() {
-                            return km = arguments[0];
-                          };
-                        })(),
-                        lineno: 318
-                      })));
-                      __iced_deferrals._fulfill();
-                    })(function() {
-                      (function(__iced_k) {
-                        __iced_deferrals = new iced.Deferrals(__iced_k, {
-                          parent: ___iced_passed_deferral,
-                          filename: "/Users/sidney/src/keybase/node-forge-sigchain/src/forge.iced",
-                          funcname: "Forge.forge"
+                      if (parts.gen) {
+                        (function(__iced_k) {
+                          __iced_deferrals = new iced.Deferrals(__iced_k, {
+                            parent: ___iced_passed_deferral,
+                            filename: "/home/zapu/pgp/mikeboers/node-forge-sigchain/src/forge.iced",
+                            funcname: "Forge.forge"
+                          });
+                          _this._gen_key({
+                            obj: parts.gen
+                          }, esc(__iced_deferrals.defer({
+                            lineno: 369
+                          })));
+                          __iced_deferrals._fulfill();
+                        })(__iced_k);
+                      } else {
+                        (function(__iced_k) {
+                          __iced_deferrals = new iced.Deferrals(__iced_k, {
+                            parent: ___iced_passed_deferral,
+                            filename: "/home/zapu/pgp/mikeboers/node-forge-sigchain/src/forge.iced",
+                            funcname: "Forge.forge"
+                          });
+                          kbpgp.KeyManager.import_from_armored_pgp({
+                            armored: parts["public"]
+                          }, esc(__iced_deferrals.defer({
+                            assign_fn: (function() {
+                              return function() {
+                                return km = arguments[0];
+                              };
+                            })(),
+                            lineno: 371
+                          })));
+                          __iced_deferrals._fulfill();
+                        })(function() {
+                          (function(__iced_k) {
+                            __iced_deferrals = new iced.Deferrals(__iced_k, {
+                              parent: ___iced_passed_deferral,
+                              filename: "/home/zapu/pgp/mikeboers/node-forge-sigchain/src/forge.iced",
+                              funcname: "Forge.forge"
+                            });
+                            km.merge_pgp_private({
+                              armored: parts["private"]
+                            }, esc(__iced_deferrals.defer({
+                              lineno: 372
+                            })));
+                            __iced_deferrals._fulfill();
+                          })(function() {
+                            k = new Key({
+                              km: km,
+                              ctime: _this._compute_now(),
+                              expire_in: _this._expire_in
+                            });
+                            _this._keyring.bundles.push(parts["public"]);
+                            return __iced_k(_this._keyring.label[name] = k);
+                          });
                         });
-                        km.merge_pgp_private({
-                          armored: parts["private"]
-                        }, esc(__iced_deferrals.defer({
-                          lineno: 319
-                        })));
-                        __iced_deferrals._fulfill();
-                      })(function() {
-                        k = new Key({
-                          km: km,
-                          ctime: _this._compute_now(),
-                          expire_in: _this._expire_in
-                        });
-                        _this._keyring.bundles.push(parts["public"]);
-                        return _next(_this._keyring.label[name] = k);
-                      });
-                    });
+                      }
+                    })(_next);
                   }
                 };
                 _while(__iced_k);
@@ -1011,7 +1120,7 @@
                   (function(__iced_k) {
                     __iced_deferrals = new iced.Deferrals(__iced_k, {
                       parent: ___iced_passed_deferral,
-                      filename: "/Users/sidney/src/keybase/node-forge-sigchain/src/forge.iced",
+                      filename: "/home/zapu/pgp/mikeboers/node-forge-sigchain/src/forge.iced",
                       funcname: "Forge.forge"
                     });
                     _this._forge_link({
@@ -1022,7 +1131,7 @@
                           return out = arguments[0];
                         };
                       })(),
-                      lineno: 324
+                      lineno: 377
                     })));
                     __iced_deferrals._fulfill();
                   })(_next);


### PR DESCRIPTION
Mostly `pgp_update` improvements. It can change expiration times and change identities now. This was used to test signature chain verification for expiration bugs where expiring pgp key was invalidating the whole chain.

Changes to `_compute_time`: it is used for more things now (like `key.generated` for key generation time, which might be different than link creation time), but `_compute_time` will only advance simulation clock when handling `linkdesc.ctime`, and it will always happen at the very beginning of forging link (used to be in `_populate_proof` so at the very end).

`4.cson` has an example of pgp_update that moves key expiration and changes identity name.